### PR TITLE
Complete base build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ RUN wget --no-verbose -O shiny-server.deb ${SHINY_VERSION} \
 # install R packages
 RUN R -e "install.packages(c('rmarkdown', 'devtools', 'shiny', 'DT'), repos='http://cran.rstudio.com/', lib='/usr/lib/R/site-library', dependencies=T)" \
     && R -e "devtools::install_github('ramnathv/rCharts')"
+    
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # expose ports
 EXPOSE 3838


### PR DESCRIPTION
Add clean up line to file; no need to copy the "shiny-server" file because this isn't necessary (from Rafal's Dockerfile). 

Not sure what the main reasons behind using phusion are; I don't really see the need for it (SSH is cool, but we will never need it in practice - the iNZight developers won't have access anyway).
